### PR TITLE
Add annotations export

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A window will appear prompting you to select the person to track. Once selected,
 
 This step relies on our [custom fork of SAM2](https://github.com/cjaverliat/sam2) to run without requiring the entire video to be loaded into RAM or VRAM (which led to OOM in the original implementation), to define custom memory/forgetting strategies and to use EfficientTAM for faster inference.
 
-The pipeline will output results in the `outputs/infer_nlf_single_person_sam2/offline_demo/` folder, including a `.rrd` rerun file that can be visualized with [Rerun](https://www.rerun.io/), along with a `.bvh` file that can be imported in Blender, Maya, Unity, Unreal Engine, etc.
+The pipeline will output results in the `outputs/infer_nlf_single_person_sam2/offline_demo/` folder, including all generated annotations in `.pkl` format (e.g. bboxes, camera parameters, 3D keypoints, etc.), a `.rrd` rerun file that can be visualized with [Rerun](https://www.rerun.io/), along with a `.bvh` file that can be imported in Blender, Maya, Unity, Unreal Engine, etc.
 
 <div align="center" style="display: flex; justify-content: center; flex-direction: column;">
     <img src="docs/static/images/stone_quarry_rrd.gif" alt="Stone Quarry Rerun" width="500">

--- a/configs/demo/offline/dwpose_single_person.yaml
+++ b/configs/demo/offline/dwpose_single_person.yaml
@@ -228,3 +228,14 @@ pipeline:
         log_gt_skeletons_2d: False
         log_gt_skeletons_3d: False
         log_gt_cameras: False
+
+    annotations_export:
+      _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportStage
+      name: "Annotations Export"
+      order: 170
+      runtime_cfg:
+        _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportRuntimeConfig
+        annotations_keys: "*"
+        excluded_annotations_keys: []
+        not_found_error: False
+        output_path_template: "${output_root_dir}/offline_demo/annotations/{sequence_name}/{annotation_key}.pkl"

--- a/configs/demo/offline/dwpose_single_person_sam2.yaml
+++ b/configs/demo/offline/dwpose_single_person_sam2.yaml
@@ -244,3 +244,14 @@ pipeline:
         log_gt_skeletons_2d: False
         log_gt_skeletons_3d: False
         log_gt_cameras: False
+
+    annotations_export:
+      _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportStage
+      name: "Annotations Export"
+      order: 170
+      runtime_cfg:
+        _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportRuntimeConfig
+        annotations_keys: "*"
+        excluded_annotations_keys: []
+        not_found_error: False
+        output_path_template: "${output_root_dir}/offline_demo/annotations/{sequence_name}/{annotation_key}.pkl"

--- a/configs/demo/offline/nlf_single_person.yaml
+++ b/configs/demo/offline/nlf_single_person.yaml
@@ -313,3 +313,14 @@ pipeline:
         log_gt_skeletons_2d: False
         log_gt_skeletons_3d: False
         log_gt_cameras: False
+
+    annotations_export:
+      _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportStage
+      name: "Annotations Export"
+      order: 170
+      runtime_cfg:
+        _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportRuntimeConfig
+        annotations_keys: "*"
+        excluded_annotations_keys: []
+        not_found_error: False
+        output_path_template: "${output_root_dir}/offline_demo/annotations/{sequence_name}/{annotation_key}.pkl"

--- a/configs/demo/offline/nlf_single_person_sam2.yaml
+++ b/configs/demo/offline/nlf_single_person_sam2.yaml
@@ -316,3 +316,14 @@ pipeline:
         log_gt_skeletons_2d: False
         log_gt_skeletons_3d: False
         log_gt_cameras: False
+
+    annotations_export:
+      _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportStage
+      name: "Annotations Export"
+      order: 170
+      runtime_cfg:
+        _target_: kineo.pipeline.stages.annotations_export.AnnotationsExportRuntimeConfig
+        annotations_keys: "*"
+        excluded_annotations_keys: []
+        not_found_error: False
+        output_path_template: "${output_root_dir}/offline_demo/annotations/{sequence_name}/{annotation_key}.pkl"


### PR DESCRIPTION
Export all of the annotations generated by the demo in the **/offline_demo/annotations/* folder as pickle files.

This is useful to access SMPL or camera parameters for downstream tasks, as requested in #3.

Closes #3 